### PR TITLE
Implement SMTP email functionality and refactor request handlers

### DIFF
--- a/lambda_functions/request_manager/actions/stmp.go
+++ b/lambda_functions/request_manager/actions/stmp.go
@@ -1,0 +1,51 @@
+package actions
+
+import (
+	"fmt"
+	"net/smtp"
+	"os"
+)
+
+var (
+	smtpServer = "smtp.gmail.com"
+	smtpPort   = "587"
+	username   = os.Getenv("GMAIL_USERNAME") // 환경 변수에서 가져오기
+	password   = os.Getenv("GMAIL_PASSWORD") // 앱 비밀번호 사용
+)
+
+type EmailRequest struct {
+	To      string `json:"to"`
+	Subject string `json:"subject"`
+	Body    string `json:"body"`
+}
+
+// EmailSender is a function type for sending emails
+type EmailSender func(to, subject, body string) error
+
+type SMTPManagerIFace interface {
+	SendEmailWithGoogle(to, subject, body string) error
+}
+
+type SMTPManager struct{}
+
+func (r *SMTPManager) SendEmailWithGoogle(to, subject, body string) error {
+	auth := smtp.PlainAuth("", username, password, smtpServer)
+	// 이메일 포맷
+	msg := []byte(fmt.Sprintf(
+		"To: %s\r\n"+
+			"Subject: %s\r\n"+
+			"\r\n"+
+			"%s\r\n", to, subject, body,
+	))
+
+	// SMTP 서버에 연결하여 이메일 전송
+	err := smtp.SendMail(smtpServer+":"+smtpPort, auth, username, []string{to}, msg)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func SendEmail(sender SMTPManagerIFace, to, subject, body string) error {
+	return sender.SendEmailWithGoogle(to, subject, body)
+}

--- a/lambda_functions/request_manager/actions/table.go
+++ b/lambda_functions/request_manager/actions/table.go
@@ -84,14 +84,10 @@ func DeleteReservationItem(ctx context.Context, ddbClient DDBClientiface, key ma
 		Key:       key,
 	})
 
-	if err != nil {
-		log.Errorln("err", err)
-	}
-
 	return err
 }
 
-func IsItemExist(ctx context.Context, ddbClient DDBClientiface, tableName string, key map[string]types.AttributeValue) (bool, error) {
+func IsItemExist(ctx context.Context, ddbClient DDBClientiface, tableName string, key map[string]types.AttributeValue) (map[string]types.AttributeValue, error) {
 	result, err := ddbClient.GetItem(ctx, &dynamodb.GetItemInput{
 		TableName: &tableName,
 		Key:       key,
@@ -99,10 +95,10 @@ func IsItemExist(ctx context.Context, ddbClient DDBClientiface, tableName string
 
 	if err != nil {
 		log.Errorln("err", err)
-		return false, err
+		return nil, err
 	}
 
-	return result.Item != nil, nil
+	return result.Item, nil
 }
 func GetPendingItem(ctx context.Context, ddbClient DDBClientiface, key map[string]types.AttributeValue) (map[string]types.AttributeValue, error) {
 	tableName := "pending_reservation"

--- a/lambda_functions/request_manager/go.mod
+++ b/lambda_functions/request_manager/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-lambda-go v1.47.0
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.9
+	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.18.7
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression v1.7.73
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.41.1
 	github.com/sirupsen/logrus v1.9.3
@@ -14,7 +15,6 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.62 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.18.7 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect

--- a/lambda_functions/request_manager/handlers/get_pending_reservations.go
+++ b/lambda_functions/request_manager/handlers/get_pending_reservations.go
@@ -9,9 +9,11 @@ import (
 	"request_manager/response"
 )
 
-func GetPendingReservations(ctx context.Context, request events.APIGatewayV2HTTPRequest, ddbClient actions.DDBClientiface) (events.APIGatewayV2HTTPResponse, error) {
-	var scanResults *dynamodb.ScanOutput
+func GetPendingReservations(params RouterHandlerParameters) (events.APIGatewayV2HTTPResponse, error) {
+	ctx := context.Background()
+	ddbClient := params.DdbClient
 
+	var scanResults *dynamodb.ScanOutput
 	scanResults, err := actions.ScanTable(ctx, ddbClient, "pending_reservation")
 	if err != nil {
 		return response.APIGatewayResponseError("Internal Server Error", 500), err

--- a/lambda_functions/request_manager/handlers/get_reservations.go
+++ b/lambda_functions/request_manager/handlers/get_reservations.go
@@ -25,7 +25,10 @@ type ReservationType struct {
 	VenueDate     string `dynamodbav:"venueDate"`
 }
 
-func GetReservations(ctx context.Context, request events.APIGatewayV2HTTPRequest, ddbClient actions.DDBClientiface) (events.APIGatewayV2HTTPResponse, error) {
+func GetReservations(params RouterHandlerParameters) (events.APIGatewayV2HTTPResponse, error) {
+	ctx := context.Background()
+	ddbClient := params.DdbClient
+
 	var scanResults *dynamodb.ScanOutput
 
 	scanResults, err := actions.ScanTable(ctx, ddbClient, "current_reservation")

--- a/lambda_functions/request_manager/handlers/router_params.go
+++ b/lambda_functions/request_manager/handlers/router_params.go
@@ -1,0 +1,14 @@
+package handlers
+
+import (
+	"context"
+	"github.com/aws/aws-lambda-go/events"
+	"request_manager/actions"
+)
+
+type RouterHandlerParameters struct {
+	Ctx        context.Context
+	Request    events.APIGatewayV2HTTPRequest
+	DdbClient  actions.DDBClientiface
+	SmtpClient actions.SMTPManagerIFace
+}

--- a/lambda_functions/request_manager/handlers/test/manage_pending_reservation_test.go
+++ b/lambda_functions/request_manager/handlers/test/manage_pending_reservation_test.go
@@ -17,6 +17,7 @@ import (
 func TestManagePendingReservation_Accept(t *testing.T) {
 	// Setup mock DynamoDB client
 	mockDDB := &mocks.MockDDBClient{}
+	mockSMTP := &mocks.MockSendEmail{}
 
 	// Mock reservation data
 	requestId := "test-reservation-id"
@@ -57,12 +58,14 @@ func TestManagePendingReservation_Accept(t *testing.T) {
 			input.Key["requestId"].(*types.AttributeValueMemberS).Value == requestId
 	})).Return(&dynamodb.DeleteItemOutput{}, nil)
 
+	mockSMTP.On("SendEmailWithGoogle", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
 	// Create request body
-	requestBody := handlers.RequestDeleteType{
+	reqBody := handlers.RequestDeleteType{
 		Key:  requestId,
 		Code: "ACCEPT",
 	}
-	bodyBytes, _ := json.Marshal(requestBody)
+	bodyBytes, _ := json.Marshal(reqBody)
 
 	// Create API Gateway request
 	ctx := context.Background()
@@ -70,8 +73,16 @@ func TestManagePendingReservation_Accept(t *testing.T) {
 		Body: string(bodyBytes),
 	}
 
+	// Create handler parameters
+	params := handlers.RouterHandlerParameters{
+		Ctx:        ctx,
+		Request:    request,
+		DdbClient:  mockDDB,
+		SmtpClient: mockSMTP,
+	}
+
 	// Call the handler
-	response, err := handlers.ManagePendingReservation(ctx, request, mockDDB)
+	response, err := handlers.ManagePendingReservation(params)
 
 	// Assert results
 	assert.NoError(t, err)
@@ -79,11 +90,13 @@ func TestManagePendingReservation_Accept(t *testing.T) {
 
 	// Verify all mocks were called
 	mockDDB.AssertExpectations(t)
+	mockSMTP.AssertExpectations(t)
 }
 
 func TestManagePendingReservation_Deny(t *testing.T) {
 	// Setup mock DynamoDB client
 	mockDDB := &mocks.MockDDBClient{}
+	mockSMTP := &mocks.MockSendEmail{}
 
 	// Mock reservation data
 	requestId := "test-reservation-id"
@@ -119,6 +132,8 @@ func TestManagePendingReservation_Deny(t *testing.T) {
 			input.Key["requestId"].(*types.AttributeValueMemberS).Value == requestId
 	})).Return(&dynamodb.DeleteItemOutput{}, nil)
 
+	mockSMTP.On("SendEmailWithGoogle", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
 	// Create request body
 	requestBody := handlers.RequestDeleteType{
 		Key:  requestId,
@@ -132,8 +147,16 @@ func TestManagePendingReservation_Deny(t *testing.T) {
 		Body: string(bodyBytes),
 	}
 
+	// Create handler parameters
+	params := handlers.RouterHandlerParameters{
+		Ctx:        ctx,
+		Request:    request,
+		DdbClient:  mockDDB,
+		SmtpClient: mockSMTP,
+	}
+
 	// Call the handler
-	response, err := handlers.ManagePendingReservation(ctx, request, mockDDB)
+	response, err := handlers.ManagePendingReservation(params)
 
 	// Assert results
 	assert.NoError(t, err)
@@ -141,11 +164,13 @@ func TestManagePendingReservation_Deny(t *testing.T) {
 
 	// Verify all mocks were called
 	mockDDB.AssertExpectations(t)
+	mockSMTP.AssertExpectations(t)
 }
 
 func TestManagePendingReservation_InvalidCode(t *testing.T) {
 	// Setup mock DynamoDB client
 	mockDDB := &mocks.MockDDBClient{}
+	mockSMTP := &mocks.MockSendEmail{}
 
 	// Mock reservation data
 	requestId := "test-reservation-id"
@@ -174,8 +199,16 @@ func TestManagePendingReservation_InvalidCode(t *testing.T) {
 		Body: string(bodyBytes),
 	}
 
+	// Create handler parameters
+	params := handlers.RouterHandlerParameters{
+		Ctx:        ctx,
+		Request:    request,
+		DdbClient:  mockDDB,
+		SmtpClient: mockSMTP,
+	}
+
 	// Call the handler
-	response, err := handlers.ManagePendingReservation(ctx, request, mockDDB)
+	response, err := handlers.ManagePendingReservation(params)
 
 	// Assert results
 	assert.NoError(t, err)
@@ -183,4 +216,5 @@ func TestManagePendingReservation_InvalidCode(t *testing.T) {
 
 	// Verify mocks were called
 	mockDDB.AssertExpectations(t)
+	mockSMTP.AssertExpectations(t)
 }

--- a/lambda_functions/request_manager/mocks/main.go
+++ b/lambda_functions/request_manager/mocks/main.go
@@ -35,3 +35,12 @@ func (m *MockDDBClient) UpdateItem(ctx context.Context, params *dynamodb.UpdateI
 	args := m.Called(ctx, params)
 	return args.Get(0).(*dynamodb.UpdateItemOutput), args.Error(1)
 }
+
+type MockSendEmail struct {
+	mock.Mock
+}
+
+func (r *MockSendEmail) SendEmailWithGoogle(to, subject, body string) error {
+	args := r.Called(to, subject, body)
+	return args.Error(0)
+}


### PR DESCRIPTION
- Added SMTPManager for sending emails using Gmail SMTP.
- Updated request handlers to use RouterHandlerParameters for better parameter management.
- Refactored GetPendingReservations, ManagePendingReservation, and ManageReservation handlers to utilize the new structure and send email notifications upon reservation acceptance or cancellation.
- Adjusted tests to mock SMTP interactions and validate email sending functionality.

## 🗒️ 변경 사항


## 🗣️ 기타 사항
